### PR TITLE
add FAQ component to education sample

### DIFF
--- a/src/api/education-sample/content-types/education-sample/schema.json
+++ b/src/api/education-sample/content-types/education-sample/schema.json
@@ -62,6 +62,11 @@
       "type": "component",
       "component": "shared.article-with-plain-title",
       "repeatable": true
+    },
+    "faqs": {
+      "type": "component",
+      "component": "shared.faq",
+      "repeatable": true
     }
   }
 }

--- a/src/components/shared/faq.json
+++ b/src/components/shared/faq.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_shared_faqs",
+  "info": {
+    "displayName": "Faq",
+    "icon": "bulletList"
+  },
+  "options": {},
+  "attributes": {
+    "question": {
+      "type": "string",
+      "required": true
+    },
+    "answer": {
+      "type": "text",
+      "required": true
+    }
+  },
+  "config": {}
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -77,6 +77,18 @@ export interface SharedBanner extends Struct.ComponentSchema {
   };
 }
 
+export interface SharedFaq extends Struct.ComponentSchema {
+  collectionName: 'components_shared_faqs';
+  info: {
+    displayName: 'Faq';
+    icon: 'bulletList';
+  };
+  attributes: {
+    answer: Schema.Attribute.Text & Schema.Attribute.Required;
+    question: Schema.Attribute.String & Schema.Attribute.Required;
+  };
+}
+
 export interface SharedList extends Struct.ComponentSchema {
   collectionName: 'components_shared_lists';
   info: {
@@ -185,6 +197,7 @@ declare module '@strapi/strapi' {
       'shared.article': SharedArticle;
       'shared.article-with-plain-title': SharedArticleWithPlainTitle;
       'shared.banner': SharedBanner;
+      'shared.faq': SharedFaq;
       'shared.list': SharedList;
       'shared.meta-tag': SharedMetaTag;
       'shared.product-card': SharedProductCard;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1205,6 +1205,7 @@ export interface ApiEducationSampleEducationSample
     educationId: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.Unique;
+    faqs: Schema.Attribute.Component<'shared.faq', true>;
     infographicImage: Schema.Attribute.Media<'images'>;
     level: Schema.Attribute.String & Schema.Attribute.Required;
     locale: Schema.Attribute.String & Schema.Attribute.Private;


### PR DESCRIPTION
Adds a shared.faq component (question/answer) and wires it as a repeatable faqs field on the education-sample content type.